### PR TITLE
Go version updated to 1.17 to resolve psirt issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/ibm-grafana-ocpthanos-proxy
 
-go 1.16
+go 1.17
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
Go version updated to resolve PSIRT issue 
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/49206  