### PR TITLE
Updating the GO version for Twistlock vulnarability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #
 
 #Always get the latest
-FROM golang:1.17.6 as builder
+FROM golang:1.17.7 as builder
 ARG GOARCH
 
 WORKDIR /workspace


### PR DESCRIPTION
For Parent:
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/51935


Vulnerabilities : CVE-2022-23772, CVE-2022-23806, CVE-2022-23773