### PR TITLE
Go version Updated to 1.19.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #
 
 #Always get the latest
-FROM golang:1.19.6 as builder
+FROM golang:1.19.7 as builder
 ARG GOARCH
 
 WORKDIR /workspace


### PR DESCRIPTION

https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57751