### PR TITLE
Go version updated to 1.19.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #
 
 #Always get the latest
-FROM golang:1.19.8 as builder
+FROM golang:1.19.10 as builder
 ARG GOARCH
 
 WORKDIR /workspace


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59197