### PR TITLE
Go version updated to 1.19.11 for CVE-2023-29406

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #
 
 #Always get the latest
-FROM golang:1.19.10-bullseye as builder
+FROM golang:1.19.11-bullseye as builder
 ARG GOARCH
 
 WORKDIR /workspace


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59601