### PR TITLE
Go version updated to 1.21.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #
 
 #Always get the latest
-FROM golang:1.21.1-bullseye as builder
+FROM golang:1.21.2-bullseye as builder
 ARG GOARCH
 
 WORKDIR /workspace


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60756